### PR TITLE
Rubrik restore integration script

### DIFF
--- a/backup-providers/rubrik/Readme.md
+++ b/backup-providers/rubrik/Readme.md
@@ -1,0 +1,55 @@
+# Rubrik Domino Restore
+The Rubrik Domino restore script provides capability to live-mount a VMDK from Rubrik storage to a MS Windows server running Domino.
+
+
+## Requirements
+* Windows Server running Domino and PowerShell 5.1+
+* Rubrik CDM
+* VMware vCenter
+* VMware PowerCLI
+* Rubrik SDK for PowerShell
+
+## Setup
+Install prerequisite PowerShell modules on the Domino Server
+
+```
+Install-Module Rubrik, VMware.PowerCLI
+```
+
+Copy the `RubrikDominoRestore.ps1` file to the directory of your preference. It's generally advisable to put this script in it's own directory, as we'll be creating additional files for tracking state and storing encrypted credentials.
+
+Run the `RubrikDominoRestore.ps1` file with no parameters. This will invoke the first-time setup for doing restores. You will need the following information prepared for first time setup:
+
+* vCenter FQDN/IP
+* vCenter username
+* vCenter password
+* Rubrik FQDN/IP
+* Rubrik Service Account Client ID
+* Rubrik Service Account Secret
+
+The Rubrik Service Account requires permissions to read snapshots and perform live-mounts. The vSphere account requires permissions to modify a VM and attach a VMDK.
+
+The first time setup will save an XML file to the same folder/directory where the .ps1 file resides. The FQDNs, usernames and encrypted passwords are stored in this XML file. It's important to note that you should run first time setup with the same account that is going to be running the script, as this account is the only one that can decript the passwords in the XML file.
+
+
+## Running a Single File Restore
+Once first time setup has been complete and the XML file exists, `RubrikDominoRestore.ps1` can be executed to restore Domino files.
+
+```
+RubrikDominoRestore.ps1 -Tag <TAG FILE PATH> -Source <PATH TO BE RESTORED> -Destination <DESTINATION PATH>
+```
+
+Example:
+```
+RubrikDominoRestore.ps1 -Tag D:\notes\data\backup-20240118.tag -Source D:\notes\data\log.nsf -Destination D:\notes\data\restore\log.nsf
+```
+
+## Running a Multi-File Restore
+The script can be run multiple times to restore multiple files with the same mount/tag. It is executed the same way, but we add a `-PersistMount` at the end to indicate we are going to continue using the same mount later. The last file in the multi-file restore should leave off the `-PersistMount` to clean up the mounted drive at the end.
+
+Example:
+```
+RubrikDominoRestore.ps1 -Tag D:\notes\data\backup-20240118.tag -Source D:\notes\data\log.nsf -Destination D:\notes\data\restore\log.nsf -PersistMount
+RubrikDominoRestore.ps1 -Tag D:\notes\data\backup-20240118.tag -Source D:\notes\data\log1.nsf -Destination D:\notes\data\restore\log1.nsf -PersistMount
+RubrikDominoRestore.ps1 -Tag D:\notes\data\backup-20240118.tag -Source D:\notes\data\log2.nsf -Destination D:\notes\data\restore\log2.nsf #NO MORE PERSISTMOUNT
+```

--- a/backup-providers/rubrik/RubrikDominoRestore.ps1
+++ b/backup-providers/rubrik/RubrikDominoRestore.ps1
@@ -1,0 +1,124 @@
+#Requires -Modules VMware.VimAutomation.Core, Rubrik
+
+param (
+    [Parameter()]
+    [String]$Tag,
+    
+    [Parameter()]
+    [String]$Source,
+
+    [Parameter()]
+    [String]$Destination,
+
+    [Parameter()]
+    [Bool]$PersistMount
+    )
+
+function convertto-datetime($epochms) {
+    Get-Date (Get-Date ((Get-Date "1970-01-01 00:00:00.000Z") + ([TimeSpan]::FromMilliSeconds($epochms)))).ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z'
+}
+
+function ConvertFrom-SecureStringToPlainText ([System.Security.SecureString]$SecureString) {
+
+    [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
+    
+        [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+    )            
+}
+
+if(!(Test-Path .\rubrik.xml)) {
+    $config = @{}
+    Write-Output "Welcome to the first time setup!"
+    $config.vcenterHost = Read-Host -Prompt "vCenter FQDN"
+    $config.vcenterUser = Read-Host -Prompt "vCenter User"
+    $config.vcenterPass = Read-Host -Prompt "vCenter Password" -AsSecureString
+    $config.rubrikHost = Read-Host -Prompt "Rubrik FQDN"
+    $config.rubrikClientId = Read-Host -Prompt "Rubrik Service Account Client ID"
+    $config.rubrikSecret = Read-Host -Prompt "Rubrik Service Account Secret" -AsSecureString
+    $config | Export-Clixml .\rubrik.xml
+    exit
+    }
+else {
+    $config = Import-Clixml .\rubrik.xml
+}
+
+$tagmount = $Tag.Split('\')[-1].Split('.')[0]
+
+If(Test-Path .\$tagmount) {
+    Write-Output "Found existing mount file: $tagmount."
+    $newDriveLetter = Get-Content $tagmount
+} else {
+    ###
+    # Connect to vCenter and Rubrik
+    Connect-VIServer -Server $config.vcenterHost -Username $config.vcenterUser -Password (ConvertFrom-SecureStringToPlainText $config.vcenterPass)
+    Connect-Rubrik -Server $config.rubrikHost -id $config.rubrikClientId -Secret (ConvertFrom-SecureStringToPlainText $config.rubrikSecret)
+
+    ###
+    # Tag Search
+    $globalSearchResult = Invoke-RubrikRESTCall -api internal -Method POST -Endpoint "search/global" -Body @{regex = $Tag}
+
+    Write-Output $globalSearchResult
+
+    $snapshotTime = convertto-datetime($globalSearchResult.data[0].snapshotTime)
+    $drive = $globalSearchResult.data[0].dirs.Split('/')[1]
+    #$filePath = $globalSearchResult.data[0].dirs[0].Replace('/','\').Substring(1)
+    $vmId = $globalSearchResult.data[0].snappableId
+    $vmName = $globalSearchResult.data[0].snappableName
+
+    ###
+    # Get vmdk from drive letter
+    $harddrives = Get-VM $vmName | Get-HardDisk
+    $vmdk = ""
+    foreach ($hd in $harddrives) {
+        if (($hd | Get-VMGuestDisk).DiskPath.Contains($drive)) {
+            $vmdk = $hd.ExtensionData.Backing.FileName
+        }
+    }
+
+    Write-Output "VMDK File: $vmdk"
+
+    ###
+    # Get Snapshot
+    $snapshot = Get-RubrikSnapshot -id $vmId -Date $snapshotTime
+
+    ###
+    # Get VMDK ID
+    $virtualDisks = Invoke-RubrikRESTCall -api internal -method GET -endpoint "vmware/vm/virtual_disk" 
+    $vmdkId = ($virtualDisks.data | Where-Object { $_.filename -contains $vmdk}).id
+
+    Write-Output "Mounting $vmdkId to VM: $vmId"
+    ###
+    # Live Mount Disk Snapshot
+    $liveMountPayload = @{
+        targetVmId = $vmId;
+        vmdkIds = @($vmdkId)
+    }
+    $mountStatus = Invoke-RubrikRESTCall -api internal -method POST -Endpoint "vmware/vm/snapshot/$($snapshot.id)/mount_disks" -body $liveMountPayload
+
+    Get-RubrikRequest -id $mountStatus.id -Type vmware/vm -WaitForCompletion
+    ### 
+    # Activate Disk
+    $disk = Get-Disk | Where-Object isOffline -eq $true
+    $disk | Set-Disk -isOffline $false
+    $newDriveLetter = ($disk | Get-Partition).driveLetter
+
+    $newDriveLetter | Out-File $tagmount
+}
+
+###
+# File copy operation
+#$destinationPath = $Destination
+#$sourcePath = $newDriveLetter + $filePath.Substring(1) + $fileName
+$modifedSource = $Source.Split('\')[-1]
+
+Write-Output "Copying $($newDriveLetter + $modifedSource) to $Destination"
+Copy-Item ($newDriveLetter + $modifedSource) $Destination
+
+###
+# Unmount
+# By default, mounts will be cleaned up after a single file restore.
+# If this is a multi-file restore, you must use -PersistMount until the last file.
+if (!$PersistMount) {
+    Remove-RubrikMount -id $mountStatus.id
+    Remove-Item $tagmount
+}

--- a/backup-providers/rubrik/RubrikDominoRestore.ps1
+++ b/backup-providers/rubrik/RubrikDominoRestore.ps1
@@ -11,13 +11,15 @@ param (
     [String]$Destination,
 
     [Parameter()]
-    [Bool]$PersistMount
+    [Switch]$PersistMount
     )
 
+# The time we get from global file search is in epoch ms. We need to convert it.
 function convertto-datetime($epochms) {
     Get-Date (Get-Date ((Get-Date "1970-01-01 00:00:00.000Z") + ([TimeSpan]::FromMilliSeconds($epochms)))).ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z'
 }
 
+# PowerShell 5.1 does not have the -AsPlainText attribute for converting from SecureString. This function compensates.
 function ConvertFrom-SecureStringToPlainText ([System.Security.SecureString]$SecureString) {
 
     [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
@@ -26,6 +28,7 @@ function ConvertFrom-SecureStringToPlainText ([System.Security.SecureString]$Sec
     )            
 }
 
+# First Time Setup
 if(!(Test-Path .\rubrik.xml)) {
     $config = @{}
     Write-Output "Welcome to the first time setup!"
@@ -42,11 +45,15 @@ else {
     $config = Import-Clixml .\rubrik.xml
 }
 
+# Using the tag as a filename to keep track of any mounts we have. 
+# The file will contain the drive letter where it's mounted, and the mount id so we can unmount later.
 $tagmount = $Tag.Split('\')[-1].Split('.')[0]
 
 If(Test-Path .\$tagmount) {
-    Write-Output "Found existing mount file: $tagmount."
-    $newDriveLetter = Get-Content $tagmount
+    Write-Output "Found existing mount file for this tag: $tagmount."
+    $mountData = Get-Content .\$tagmount | ConvertFrom-Json
+    $newDriveLetter = $mountData.driveLetter
+    $mountId = $mountData.mountId
 } else {
     ###
     # Connect to vCenter and Rubrik
@@ -64,6 +71,11 @@ If(Test-Path .\$tagmount) {
     #$filePath = $globalSearchResult.data[0].dirs[0].Replace('/','\').Substring(1)
     $vmId = $globalSearchResult.data[0].snappableId
     $vmName = $globalSearchResult.data[0].snappableName
+
+    Write-Output "Global Search Result:"
+    Write-Output "Drive: $drive"
+    Write-Output "vmId: $vmId"
+    Write-Output "vmName: $vmName"
 
     ###
     # Get vmdk from drive letter
@@ -86,7 +98,7 @@ If(Test-Path .\$tagmount) {
     $virtualDisks = Invoke-RubrikRESTCall -api internal -method GET -endpoint "vmware/vm/virtual_disk" 
     $vmdkId = ($virtualDisks.data | Where-Object { $_.filename -contains $vmdk}).id
 
-    Write-Output "Mounting $vmdkId to VM: $vmId"
+    Write-Output "Mounting VMDK $vmdkId to VM: $vmId"
     ###
     # Live Mount Disk Snapshot
     $liveMountPayload = @{
@@ -96,29 +108,40 @@ If(Test-Path .\$tagmount) {
     $mountStatus = Invoke-RubrikRESTCall -api internal -method POST -Endpoint "vmware/vm/snapshot/$($snapshot.id)/mount_disks" -body $liveMountPayload
 
     Get-RubrikRequest -id $mountStatus.id -Type vmware/vm -WaitForCompletion
+    $mountId = (Get-RubrikMount | Where-Object mountRequestId -eq $mountStatus.id).id
     ### 
     # Activate Disk
     $disk = Get-Disk | Where-Object isOffline -eq $true
     $disk | Set-Disk -isOffline $false
-    $newDriveLetter = ($disk | Get-Partition).driveLetter
+    $newDriveLetter = ($disk | Get-Partition).driveLetter + ":"
+    Get-Volume -DriveLetter $newDriveLetter.split(":")[0] | Set-Volume -NewFileSystemLabel "Restore-$tagmount"
 
-    $newDriveLetter | Out-File $tagmount
+    # Save mount id and drive letter to file
+    $mountData = @{driveLetter = $newDriveLetter; mountId = $mountId}
+    $mountData | ConvertTo-Json | Out-File $tagmount
+
+    Disconnect-VIServer -Force -Confirm:$false
+    Disconnect-Rubrik
 }
 
 ###
 # File copy operation
 #$destinationPath = $Destination
 #$sourcePath = $newDriveLetter + $filePath.Substring(1) + $fileName
-$modifedSource = $Source.Split('\')[-1]
+$modifedSource = $Source.Split(':')[-1]
 
 Write-Output "Copying $($newDriveLetter + $modifedSource) to $Destination"
-Copy-Item ($newDriveLetter + $modifedSource) $Destination
+New-Item $Destination -Force
+Copy-Item (Join-Path $newDriveLetter $modifedSource) $Destination -Force
 
 ###
 # Unmount
 # By default, mounts will be cleaned up after a single file restore.
 # If this is a multi-file restore, you must use -PersistMount until the last file.
 if (!$PersistMount) {
-    Remove-RubrikMount -id $mountStatus.id
+    Connect-Rubrik -Server $config.rubrikHost -id $config.rubrikClientId -Secret (ConvertFrom-SecureStringToPlainText $config.rubrikSecret)
+    Remove-RubrikMount -id $mountId
     Remove-Item $tagmount
+    Disconnect-Rubrik
 }
+


### PR DESCRIPTION
# Rubrik Domino Restore
The Rubrik Domino restore script provides capability to live-mount a VMDK from Rubrik storage to a MS Windows server running Domino.


## Requirements
* Windows Server running Domino and PowerShell 5.1+
* Rubrik CDM
* VMware vCenter
* VMware PowerCLI
* Rubrik SDK for PowerShell

## Setup
Install prerequisite PowerShell modules on the Domino Server

```
Install-Module Rubrik, VMware.PowerCLI
```

Copy the `RubrikDominoRestore.ps1` file to the directory of your preference. It's generally advisable to put this script in it's own directory, as we'll be creating additional files for tracking state and storing encrypted credentials.

Run the `RubrikDominoRestore.ps1` file with no parameters. This will invoke the first-time setup for doing restores. You will need the following information prepared for first time setup:

* vCenter FQDN/IP
* vCenter username
* vCenter password
* Rubrik FQDN/IP
* Rubrik Service Account Client ID
* Rubrik Service Account Secret

The Rubrik Service Account requires permissions to read snapshots and perform live-mounts. The vSphere account requires permissions to modify a VM and attach a VMDK.

The first time setup will save an XML file to the same folder/directory where the .ps1 file resides. The FQDNs, usernames and encrypted passwords are stored in this XML file. It's important to note that you should run first time setup with the same account that is going to be running the script, as this account is the only one that can decript the passwords in the XML file.


## Running a Single File Restore
Once first time setup has been complete and the XML file exists, `RubrikDominoRestore.ps1` can be executed to restore Domino files.

```
RubrikDominoRestore.ps1 -Tag <TAG FILE PATH> -Source <PATH TO BE RESTORED> -Destination <DESTINATION PATH>
```

Example:
```
RubrikDominoRestore.ps1 -Tag D:\notes\data\backup-20240118.tag -Source D:\notes\data\log.nsf -Destination D:\notes\data\restore\log.nsf
```

## Running a Multi-File Restore
The script can be run multiple times to restore multiple files with the same mount/tag. It is executed the same way, but we add a `-PersistMount` at the end to indicate we are going to continue using the same mount later. The last file in the multi-file restore should leave off the `-PersistMount` to clean up the mounted drive at the end.

Example:
```
RubrikDominoRestore.ps1 -Tag D:\notes\data\backup-20240118.tag -Source D:\notes\data\log.nsf -Destination D:\notes\data\restore\log.nsf -PersistMount
RubrikDominoRestore.ps1 -Tag D:\notes\data\backup-20240118.tag -Source D:\notes\data\log1.nsf -Destination D:\notes\data\restore\log1.nsf -PersistMount
RubrikDominoRestore.ps1 -Tag D:\notes\data\backup-20240118.tag -Source D:\notes\data\log2.nsf -Destination D:\notes\data\restore\log2.nsf #NO MORE PERSISTMOUNT
```